### PR TITLE
Add ability to reuse root dir for version instead of building version to separate directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,11 @@ Oro Doc modifications
 
 This modification includes next changes:
 
-* Added "version_dirs" configuration option which allows to set name of destination directory for specific version (before branch name has been used)
-* Added "vpathto_or_none" function to Jinja2 context and use it when passing branch/tag versions to template. If document is not present in specific version then this version will not be added and displayed on UI for this document
-* Added "scv_root_ref" variable to Jinja2 context with ref name of the root
+* Added `version_dirs` configuration option which allows to set name of destination directory for specific version (before branch name has been used)
+* Added `vpathto_or_none` function to Jinja2 context and use it when passing branch/tag versions to template. If document is not present in specific version then this version will not be added and displayed on UI for this document
+* Added `scv_root_ref` variable to Jinja2 context with ref name of the root
+* Added `oro_current_version` variable to Jinja2 context with version name processed by "version_dirs" configuration
+* Added `-R/--reuse-root` option to `build` command which allows to reuse existing root instead of additional building separate directory for root version.
 
 General
 -------

--- a/sphinxcontrib/versioning/__main__.py
+++ b/sphinxcontrib/versioning/__main__.py
@@ -193,6 +193,8 @@ def build_options(func):
                         help="Group these kinds of versions at the top (for themes that don't separate them).")(func)
     func = click.option('-r', '--root-ref',
                         help='The branch/tag at the root of DESTINATION. Will also be in subdir. Default master.')(func)
+    func = click.option('-R', '--reuse-root',
+                        help='Don\'t build root version to separate directory but reuse it')(func)
     func = click.option('-s', '--sort', multiple=True, type=click.Choice(('semver', 'alpha', 'time')),
                         help='Sort versions. Specify multiple times to sort equal values of one kind.')(func)
     func = click.option('-t', '--greatest-tag', is_flag=True,
@@ -280,7 +282,8 @@ def build(config, rel_source, destination, **options):
         sort=config.sort,
         priority=config.priority,
         invert=config.invert,
-        version_dirs=config.version_dirs
+        version_dirs=config.version_dirs,
+        reuse_root=config.reuse_root
     )
 
     # Get root ref.

--- a/sphinxcontrib/versioning/lib.py
+++ b/sphinxcontrib/versioning/lib.py
@@ -28,6 +28,7 @@ class Config(object):
         self.no_local_conf = False
         self.recent_tag = False
         self.show_banner = False
+        self.reuse_root = False
 
         # Strings.
         self.banner_main_ref = 'master'

--- a/sphinxcontrib/versioning/routines.py
+++ b/sphinxcontrib/versioning/routines.py
@@ -164,14 +164,21 @@ def build_all(exported_root, destination, versions):
     log = logging.getLogger(__name__)
 
     while True:
+        config = Config.from_context()
+
         # Build root.
-        remote = versions[Config.from_context().root_ref]
-        log.info('Building root: %s', remote['name'])
-        source = os.path.dirname(os.path.join(exported_root, remote['sha'], remote['conf_rel_path']))
-        build(source, destination, versions, remote['name'], True)
+        root_remote = versions[config.root_ref]
+
+        log.info('Building root: %s', root_remote['name'])
+        source = os.path.dirname(os.path.join(exported_root, root_remote['sha'], root_remote['conf_rel_path']))
+        build(source, destination, versions, root_remote['name'], True)
 
         # Build all refs.
         for remote in list(versions.remotes):
+            # Skip building root to separate directory
+            if config.reuse_root and remote['name'] == root_remote['name']:
+                continue
+
             log.info('Building ref: %s', remote['name'])
             source = os.path.dirname(os.path.join(exported_root, remote['sha'], remote['conf_rel_path']))
             target = os.path.join(destination, remote['root_dir'])

--- a/sphinxcontrib/versioning/sphinx_.py
+++ b/sphinxcontrib/versioning/sphinx_.py
@@ -96,6 +96,7 @@ class EventHandlers(object):
         # Update Jinja2 context.
         context['bitbucket_version'] = cls.CURRENT_VERSION
         context['current_version'] = cls.CURRENT_VERSION
+        context['oro_current_version'] = config.version_dirs.get(cls.CURRENT_VERSION, cls.CURRENT_VERSION)
         context['github_version'] = cls.CURRENT_VERSION
         context['html_theme'] = app.config.html_theme
         context['scv_banner_greatest_tag'] = cls.BANNER_GREATEST_TAG


### PR DESCRIPTION
 - Add `oro_current_version` variable to Jinja2 context
 - add `-R/--reuse-root` to enable reuse feature